### PR TITLE
function fix: checkCoordinate

### DIFF
--- a/initial/js_node
+++ b/initial/js_node
@@ -15,7 +15,7 @@ if (!global.is_checking) {
     var checkCoordinate = function (coor) {
         var c = coor[0];
         var r = coor[1];
-        return COLS.indexOf(c) !== -1 && ROWS.indexOf(r);
+        return COLS.indexOf(c) !== -1 && ROWS.indexOf(r) !== -1;
 
     };
 


### PR DESCRIPTION
In case we have to place a queen in first row, the `checkCoordinate` function would have never evaluated this solution as true.
